### PR TITLE
Add Open Graph and Twitter card images

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,6 +35,12 @@ export const metadata: Metadata = {
     locale: 'en_US',
     type: 'website',
   },
+  twitter: {
+    card: 'summary_large_image',
+    title: siteMetadata.title,
+    description: siteMetadata.description,
+    images: [siteMetadata.socialBanner],
+  },
   alternates: {
     canonical: './',
     types: {

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,159 @@
+import { ImageResponse } from 'next/og'
+import siteMetadata from '@/data/siteMetadata'
+
+export const runtime = 'edge'
+export const alt = siteMetadata.title
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default async function Image() {
+  return new ImageResponse(
+    <div
+      style={{
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 48,
+        backgroundColor: '#000000',
+        backgroundImage:
+          "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Ccircle cx='2' cy='2' r='1' fill='%23202530'/%3E%3C/svg%3E\")",
+        backgroundSize: '18px 18px',
+        backgroundRepeat: 'repeat',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          inset: 30,
+          opacity: 0.55,
+          display: 'flex',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            borderRadius: 32,
+            border: '1px solid rgba(255,255,255,0.08)',
+          }}
+        />
+      </div>
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          borderRadius: 22,
+          border: '1px solid rgba(255,255,255,0.08)',
+          backgroundColor: '#000103',
+          boxShadow: '0 20px 45px rgba(15, 23, 42, 0.08)',
+          padding: 56,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          position: 'relative',
+          zIndex: 1,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <div
+            style={{
+              width: 44,
+              height: 44,
+              borderRadius: 12,
+              border: '1px solid rgba(249,115,22,0.4)',
+              backgroundColor: 'rgba(249,115,22,0.12)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: '#f97316',
+              fontSize: 22,
+              fontWeight: 700,
+            }}
+          >
+            SB
+          </div>
+          <span
+            style={{
+              color: '#f5f5f5',
+              fontSize: 22,
+              letterSpacing: 1.5,
+              textTransform: 'uppercase',
+            }}
+          >
+            Latest Notes
+          </span>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 22 }}>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <span
+              style={{
+                fontSize: 64,
+                fontWeight: 700,
+                color: '#f97316',
+              }}
+            >
+              {'<'}
+            </span>
+            <span
+              style={{
+                fontSize: 64,
+                fontWeight: 700,
+                color: '#f5f5f5',
+              }}
+            >
+              {siteMetadata.author}
+            </span>
+            <span
+              style={{
+                fontSize: 64,
+                fontWeight: 700,
+                color: '#f97316',
+              }}
+            >
+              {' />'}
+            </span>
+          </div>
+
+          <div
+            style={{
+              fontSize: 28,
+              color: '#9ca3af',
+            }}
+          >
+            {siteMetadata.description}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 20,
+              color: '#f97316',
+            }}
+          >
+            Dev Notes & Snippets
+          </div>
+          <div
+            style={{
+              fontSize: 20,
+              color: '#6b7280',
+            }}
+          >
+            saad.sh
+          </div>
+        </div>
+      </div>
+    </div>,
+    { ...size }
+  )
+}

--- a/app/posts/[...slug]/page.tsx
+++ b/app/posts/[...slug]/page.tsx
@@ -38,10 +38,9 @@ export async function generateMetadata(props: {
   const publishedAt = new Date(post.date).toISOString()
   const modifiedAt = new Date(post.lastmod || post.date).toISOString()
   const authors = authorDetails.map((author) => author.name)
-  let imageList = [siteMetadata.socialBanner]
-  if (post.images) {
-    imageList = typeof post.images === 'string' ? [post.images] : post.images
-  }
+  const encodedSlug = Buffer.from(slug).toString('base64url')
+  const ogImage = `/posts/og/${encodedSlug}/opengraph-image`
+  const twitterImage = `/posts/og/${encodedSlug}/twitter-image`
 
   return {
     title: post.title,
@@ -50,12 +49,19 @@ export async function generateMetadata(props: {
       title: post.title,
       description: post.summary,
       siteName: siteMetadata.title,
+      images: [ogImage],
       locale: 'en_US',
       type: 'article',
       publishedTime: publishedAt,
       modifiedTime: modifiedAt,
       url: './',
       authors: authors.length > 0 ? authors : [siteMetadata.author],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.summary,
+      images: [twitterImage],
     },
   }
 }

--- a/app/posts/og/[slug]/opengraph-image.tsx
+++ b/app/posts/og/[slug]/opengraph-image.tsx
@@ -1,0 +1,220 @@
+import { ImageResponse } from 'next/og'
+import { allPosts } from 'contentlayer/generated'
+import siteMetadata from '@/data/siteMetadata'
+
+export const alt = 'Blog Post'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+export const runtime = 'edge'
+
+const iconColors: Record<string, string> = {
+  Flutter: '#02569B',
+  Chrome: '#4285F4',
+  Python: '#3776AB',
+  Typescript: '#3178C6',
+  Javascript: '#F7DF1E',
+  Git: '#F05032',
+  GitHub: '#ffffff',
+  Jest: '#C21325',
+  Next: '#ffffff',
+  Nest: '#E0234E',
+  Shell: '#4EAA25',
+  Docker: '#2496ED',
+  Bot: '#f97316',
+  Dart: '#0175C2',
+  Flask: '#000000',
+  Postgres: '#4169E1',
+  React: '#61DAFB',
+}
+
+export default async function Image({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const postSlug = Buffer.from(slug, 'base64url').toString('utf8')
+  const post = allPosts.find((p) => p.slug === postSlug)
+
+  const title = post?.title || 'Blog Post'
+  const icon = post?.icon || 'Bot'
+  const iconColor = iconColors[icon] || '#f97316'
+
+  // Adjust font size based on title length
+  const titleFontSize = title.length > 60 ? 42 : title.length > 40 ? 52 : 64
+
+  return new ImageResponse(
+    <div
+      style={{
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 48,
+        backgroundColor: '#000000',
+        backgroundImage:
+          "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Ccircle cx='2' cy='2' r='1' fill='%23202530'/%3E%3C/svg%3E\")",
+        backgroundSize: '18px 18px',
+        backgroundRepeat: 'repeat',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          inset: 30,
+          opacity: 0.55,
+          display: 'flex',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            borderRadius: 32,
+            border: '1px solid rgba(255,255,255,0.08)',
+          }}
+        />
+      </div>
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          borderRadius: 22,
+          border: '1px solid rgba(255,255,255,0.08)',
+          backgroundColor: '#000103',
+          boxShadow: '0 20px 45px rgba(15, 23, 42, 0.08)',
+          padding: 56,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          position: 'relative',
+          zIndex: 1,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+            <div
+              style={{
+                width: 64,
+                height: 64,
+                backgroundColor: iconColor,
+                borderRadius: 16,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                boxShadow: `0 12px 30px ${iconColor}33`,
+              }}
+            >
+              <span
+                style={{
+                  color: iconColor === '#F7DF1E' || iconColor === '#ffffff' ? '#000' : '#fff',
+                  fontSize: 32,
+                  fontWeight: 700,
+                }}
+              >
+                {icon.charAt(0)}
+              </span>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <span
+                style={{
+                  fontSize: 14,
+                  color: '#9ca3af',
+                  letterSpacing: 2,
+                  textTransform: 'uppercase',
+                }}
+              >
+                Category
+              </span>
+              <span
+                style={{
+                  fontSize: 26,
+                  color: iconColor,
+                  textTransform: 'uppercase',
+                  letterSpacing: 2,
+                }}
+              >
+                {icon}
+              </span>
+            </div>
+          </div>
+          <div
+            style={{
+              padding: '8px 16px',
+              borderRadius: 999,
+              border: '1px solid rgba(249,115,22,0.35)',
+              color: '#f97316',
+              fontSize: 14,
+              letterSpacing: 2,
+              textTransform: 'uppercase',
+            }}
+          >
+            Post
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <h1
+            style={{
+              fontSize: titleFontSize,
+              fontWeight: 700,
+              color: '#f5f5f5',
+              lineHeight: 1.2,
+              margin: 0,
+            }}
+          >
+            {title}
+          </h1>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <span
+              style={{
+                fontSize: 24,
+                color: '#f97316',
+              }}
+            >
+              {'<'}
+            </span>
+            <span
+              style={{
+                fontSize: 24,
+                color: '#f5f5f5',
+              }}
+            >
+              {siteMetadata.author}
+            </span>
+            <span
+              style={{
+                fontSize: 24,
+                color: '#f97316',
+              }}
+            >
+              {' />'}
+            </span>
+          </div>
+          <span
+            style={{
+              fontSize: 20,
+              color: '#6b7280',
+            }}
+          >
+            {siteMetadata.siteUrl}
+          </span>
+        </div>
+      </div>
+    </div>,
+    { ...size }
+  )
+}

--- a/app/posts/og/[slug]/twitter-image.tsx
+++ b/app/posts/og/[slug]/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { default, alt, size, contentType } from './opengraph-image'

--- a/app/seo.tsx
+++ b/app/seo.tsx
@@ -10,6 +10,7 @@ interface PageSEOProps {
 }
 
 export function genPageMetadata({ title, description, image, ...rest }: PageSEOProps): Metadata {
+  const resolvedImage = image || siteMetadata.socialBanner
   return {
     title,
     description: description || siteMetadata.description,
@@ -18,9 +19,15 @@ export function genPageMetadata({ title, description, image, ...rest }: PageSEOP
       description: description || siteMetadata.description,
       url: './',
       siteName: siteMetadata.title,
-      images: image ? [image] : [siteMetadata.socialBanner],
+      images: [resolvedImage],
       locale: 'en_US',
       type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${title} | ${siteMetadata.title}`,
+      description: description || siteMetadata.description,
+      images: [resolvedImage],
     },
     ...rest,
   }

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { default, alt, size, contentType } from './opengraph-image'

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -10,6 +10,7 @@ const siteMetadata = {
   siteRepo: 'https://github.com/saadjs/saad.sh',
   siteLogo: '/static/images/logo.png',
   image: '/static/images/avatar.png',
+  socialBanner: '/opengraph-image',
   email: 'saadbashdev@gmail.com',
   github: 'https://github.com/saadjs',
   linkedin: 'https://www.linkedin.com/in/saadbash',


### PR DESCRIPTION
## Summary
- Add Cousine font files for OG image rendering
- Add site-wide Open Graph and Twitter card images using Next.js image generation
- Add dynamic OG images for individual blog posts with category-based styling
- Update metadata config to use new social images across the site

## Test plan
- [ ] Verify OG images render at `/opengraph-image` and `/twitter-image`
- [ ] Verify post OG images render correctly for individual posts
- [ ] Test social sharing preview on Twitter/X and other platforms