### PR TITLE
Add OG/Twitter social images and rename Bot icon to AI

### DIFF
--- a/app/posts/og/[slug]/opengraph-image.tsx
+++ b/app/posts/og/[slug]/opengraph-image.tsx
@@ -20,7 +20,7 @@ const iconColors: Record<string, string> = {
   Nest: '#E0234E',
   Shell: '#4EAA25',
   Docker: '#2496ED',
-  Bot: '#f97316',
+  AI: '#f97316',
   Dart: '#0175C2',
   Flask: '#000000',
   Postgres: '#4169E1',
@@ -33,7 +33,7 @@ export default async function Image({ params }: { params: Promise<{ slug: string
   const post = allPosts.find((p) => p.slug === postSlug)
 
   const title = post?.title || 'Blog Post'
-  const icon = post?.icon || 'Bot'
+  const icon = post?.icon || 'AI'
   const iconColor = iconColors[icon] || '#f97316'
 
   // Adjust font size based on title length

--- a/app/tag-data.json
+++ b/app/tag-data.json
@@ -1,1 +1,1 @@
-{"flutter":6,"dart":2,"javascript":6,"authjs":1,"typescript":5,"nextjs":2,"chrome":1,"ai":2,"docker":1,"postgres":1,"git":2,"github":1,"shell":1,"jest":2,"nestjs":1,"python":4}
+{"ai":2,"docker":1,"postgres":1,"javascript":6,"chrome":1,"typescript":5,"authjs":1,"nextjs":2,"python":4,"jest":2,"nestjs":1,"flutter":6,"dart":2,"git":2,"github":1,"shell":1}

--- a/components/DevIcon.tsx
+++ b/components/DevIcon.tsx
@@ -13,7 +13,7 @@ import Jest from './social-icons/jest.svg'
 import Next from './social-icons/next.svg'
 import Chrome from './social-icons/chrome.svg'
 import Docker from './social-icons/docker.svg'
-import { Bot } from './social-icons/icons'
+import { AI } from './social-icons/icons'
 
 export const DevIconsMap: Record<string, React.ComponentType<React.SVGProps<SVGSVGElement>>> = {
   Git,
@@ -30,7 +30,7 @@ export const DevIconsMap: Record<string, React.ComponentType<React.SVGProps<SVGS
   Jest,
   Next,
   Chrome,
-  Bot,
+  AI,
   Docker,
 }
 

--- a/components/social-icons/icons.tsx
+++ b/components/social-icons/icons.tsx
@@ -39,7 +39,7 @@ export function Bash(svgProps: SVGProps<SVGSVGElement>) {
     </svg>
   )
 }
-export function Bot({ className, fill: _fill, ...svgProps }: SVGProps<SVGSVGElement>) {
+export function AI({ className, fill: _fill, ...svgProps }: SVGProps<SVGSVGElement>) {
   return (
     <svg
       className={className}

--- a/data/posts/create-agent-skills.mdx
+++ b/data/posts/create-agent-skills.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Create Agent Skills in Simple Steps'
 date: '2026-01-11'
-icon: 'Bot'
+icon: 'AI'
 tags: ['ai']
 ---
 

--- a/data/posts/share-to-llms-with-query.mdx
+++ b/data/posts/share-to-llms-with-query.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Share pages and technical docs with ChatGPT, Claude, and v0 using URL queries'
 date: '2025-09-25'
-icon: 'Bot'
+icon: 'AI'
 tags: ['ai', 'javascript']
 ---
 


### PR DESCRIPTION
## Summary
- Add site-wide OpenGraph and Twitter card images for better social sharing
- Add dynamic OG images for individual blog posts with post metadata
- Rename Bot icon to AI across components and posts

## Test plan
- [ ] Verify site-wide OG image renders correctly at `/opengraph-image`
- [ ] Verify blog post OG images generate with correct title and icon
- [ ] Confirm AI icon displays properly on posts using it