### PR TITLE
Generate OG images at build time

### DIFF
--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,7 +1,6 @@
 import { ImageResponse } from 'next/og'
 import siteMetadata from '@/data/siteMetadata'
 
-export const runtime = 'edge'
 export const alt = siteMetadata.title
 export const size = { width: 1200, height: 630 }
 export const contentType = 'image/png'

--- a/app/posts/og/[slug]/opengraph-image.tsx
+++ b/app/posts/og/[slug]/opengraph-image.tsx
@@ -5,7 +5,13 @@ import siteMetadata from '@/data/siteMetadata'
 export const alt = 'Blog Post'
 export const size = { width: 1200, height: 630 }
 export const contentType = 'image/png'
-export const runtime = 'edge'
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return allPosts.map((post) => ({
+    slug: Buffer.from(post.slug, 'utf8').toString('base64url'),
+  }))
+}
 
 const iconColors: Record<string, string> = {
   Flutter: '#02569B',

--- a/app/posts/og/[slug]/twitter-image.tsx
+++ b/app/posts/og/[slug]/twitter-image.tsx
@@ -1,1 +1,8 @@
-export { default, alt, size, contentType } from './opengraph-image'
+export {
+  default,
+  alt,
+  size,
+  contentType,
+  dynamicParams,
+  generateStaticParams,
+} from './opengraph-image'


### PR DESCRIPTION
## Summary
- Remove edge runtime from OG image routes to enable static generation
- Add `generateStaticParams` to pre-render all post OG/Twitter images at build time
- Add `dynamicParams = false` to prevent on-demand generation of unknown slugs

## Test plan
- [x] Build succeeds with all OG images pre-rendered (verified locally)
- [ ] Deploy preview shows OG images load instantly from CDN